### PR TITLE
	Review: Showed message if sector level already defined at activity level

### DIFF
--- a/app/Http/Requests/Activity/Transaction/TransactionRequest.php
+++ b/app/Http/Requests/Activity/Transaction/TransactionRequest.php
@@ -284,10 +284,9 @@ class TransactionRequest extends ActivityBaseRequest
 
         $rules = [];
         $activityService = app()->make(ActivityService::class);
+        $params = $this->route()->parameters();
 
         if (!$fileUpload) {
-            $params = $this->route()->parameters();
-
             if (!$activityService->isElementEmpty($formFields, 'sectorFields') && $activityService->hasSectorDefinedInActivity($params['id'])) {
                 Validator::extend('already_in_activity', function () {
                     return false;
@@ -319,10 +318,7 @@ class TransactionRequest extends ActivityBaseRequest
         }
         $transactionService = app()->make(TransactionService::class);
 
-        if (
-            is_variable_null($formFields)
-            && $transactionService->hasSectorDefinedInTransaction($params['id'])
-        ) {
+        if (is_variable_null($formFields) && $transactionService->hasSectorDefinedInTransaction($params['id'])) {
             Validator::extend('sector_required', function () {
                 return false;
             });

--- a/app/Http/Requests/Activity/Transaction/TransactionRequest.php
+++ b/app/Http/Requests/Activity/Transaction/TransactionRequest.php
@@ -317,6 +317,17 @@ class TransactionRequest extends ActivityBaseRequest
                 $rules[$key] = $item;
             }
         }
+        $transactionService = app()->make(TransactionService::class);
+
+        if (
+            is_variable_null($formFields)
+            && $transactionService->hasSectorDefinedInTransaction($params['id'])
+        ) {
+            Validator::extend('sector_required', function () {
+                return false;
+            });
+            $rules['sector'] = 'sector_required';
+        }
 
         return $rules;
     }
@@ -330,7 +341,10 @@ class TransactionRequest extends ActivityBaseRequest
      */
     public function getSectorsMessages(array $formFields): array
     {
-        $messages = ['sector.already_in_activity' => 'Sector already defined in Activity so cannot be mentioned in transaction.'];
+        $messages = [
+            'sector.already_in_activity' => 'Sector has already been declared at activity level. You can’t declare a sector at the transaction level. To declare at transaction level, you need to remove sector at activity level.',
+            'sector.sector_required' => 'You have declared sector at transaction level so you must declare sector for all the transactions.',
+        ];
 
         if (empty($formFields)) {
             return $messages;

--- a/app/IATI/Services/Activity/TransactionService.php
+++ b/app/IATI/Services/Activity/TransactionService.php
@@ -449,4 +449,28 @@ class TransactionService
     {
         return $this->transactionRepository->delete($id);
     }
+
+    /**
+     * Checks if sector defined in one of the activity transaction.
+     *
+     * @param $activityId
+     * @return bool
+     */
+    public function hasSectorDefinedInTransaction($activityId): bool
+    {
+        $transactionData = $this->getActivityTransactions($activityId);
+
+        if (!empty($transactionData)) {
+            foreach ($transactionData as $transactionDatum) {
+                if (
+                    isset($transactionDatum->transaction['sector'])
+                    && !is_variable_null($transactionDatum->transaction['sector'])
+                ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
	- [x] Must fill up sector in transaction level if already defined in previous transaction