### PR TITLE
	Review: if recipient region or country added at activity level then va…

### DIFF
--- a/app/Http/Requests/Activity/Transaction/TransactionRequest.php
+++ b/app/Http/Requests/Activity/Transaction/TransactionRequest.php
@@ -518,7 +518,7 @@ class TransactionRequest extends ActivityBaseRequest
             }
         }
 
-        if (!is_variable_null($formFields) && !is_variable_null($this->all()['recipient_region'])) {
+        if (!is_variable_null($formFields) && !is_variable_null($this->all()['recipient_country'])) {
             Validator::extend('country_or_region', function () {
                 return false;
             });

--- a/app/Http/Requests/Activity/Transaction/TransactionRequest.php
+++ b/app/Http/Requests/Activity/Transaction/TransactionRequest.php
@@ -518,6 +518,13 @@ class TransactionRequest extends ActivityBaseRequest
             }
         }
 
+        if (!is_variable_null($formFields) && !is_variable_null($this->all()['recipient_region'])) {
+            Validator::extend('country_or_region', function () {
+                return false;
+            });
+            $rules['recipient_region'] = 'country_or_region';
+        }
+
         return $rules;
     }
 
@@ -530,7 +537,10 @@ class TransactionRequest extends ActivityBaseRequest
      */
     public function getMessagesForRecipientRegion(array $formFields): array
     {
-        $messages = ['recipient_region.already_in_activity' => 'Recipient Region already defined in Activity so cannot be mentioned in transaction.'];
+        $messages = [
+            'recipient_region.already_in_activity' => 'Recipient Region is already added at activity level. You can add a Recipient Region either at activity level or at transaction level.',
+            'recipient_region.country_or_region' => 'You must add either recipient country or recipient region.',
+        ];
 
         if (!$formFields) {
             return $messages;
@@ -600,6 +610,13 @@ class TransactionRequest extends ActivityBaseRequest
             }
         }
 
+        if (!is_variable_null($formFields) && !is_variable_null($this->all()['recipient_region'])) {
+            Validator::extend('country_or_region', function () {
+                return false;
+            });
+            $rules['recipient_country'] = 'country_or_region';
+        }
+
         return $rules;
     }
 
@@ -612,7 +629,10 @@ class TransactionRequest extends ActivityBaseRequest
      */
     public function getMessagesForRecipientCountry(array $formFields): array
     {
-        $messages = ['recipient_country.already_in_activity' => 'Recipient Country already defined in Activity so cannot be mentioned in transaction.'];
+        $messages = [
+            'recipient_country.already_in_activity' => 'Recipient Country is already added at activity level. You can add a Recipient Country either at activity level or at transaction level.',
+            'recipient_country.country_or_region' => 'You must add either recipient country or recipient region.',
+        ];
 
         if (!$formFields) {
             return $messages;

--- a/app/Http/Requests/Activity/Transaction/TransactionRequest.php
+++ b/app/Http/Requests/Activity/Transaction/TransactionRequest.php
@@ -519,7 +519,7 @@ class TransactionRequest extends ActivityBaseRequest
 
         $transactionService = app()->make(TransactionService::class);
 
-        if (($transactionService->hasRecipientRegionOrCountryDefinedInTransaction($params['id'])) || (!is_variable_null($formFields) && !is_variable_null($this->all()['recipient_country']))) {
+        if (($transactionService->hasRecipientRegionOrCountryDefinedInTransaction($params['id'])) && (!is_variable_null($formFields) && !is_variable_null($this->all()['recipient_country']))) {
             Validator::extend('country_or_region', function () {
                 return false;
             });

--- a/app/Http/Requests/Activity/Transaction/TransactionRequest.php
+++ b/app/Http/Requests/Activity/Transaction/TransactionRequest.php
@@ -487,10 +487,9 @@ class TransactionRequest extends ActivityBaseRequest
 
         $rules = [];
         $activityService = app()->make(ActivityService::class);
+        $params = $this->route()->parameters();
 
         if (!$fileUpload) {
-            $params = $this->route()->parameters();
-
             if (!$activityService->isElementEmpty($formFields, 'recipientRegionFields') && $activityService->hasRecipientRegionDefinedInActivity($params['id'])) {
                 Validator::extend('already_in_activity', function () {
                     return false;
@@ -518,7 +517,9 @@ class TransactionRequest extends ActivityBaseRequest
             }
         }
 
-        if (!is_variable_null($formFields) && !is_variable_null($this->all()['recipient_country'])) {
+        $transactionService = app()->make(TransactionService::class);
+
+        if (($transactionService->hasRecipientRegionOrCountryDefinedInTransaction($params['id'])) || (!is_variable_null($formFields) && !is_variable_null($this->all()['recipient_country']))) {
             Validator::extend('country_or_region', function () {
                 return false;
             });
@@ -538,7 +539,7 @@ class TransactionRequest extends ActivityBaseRequest
     public function getMessagesForRecipientRegion(array $formFields): array
     {
         $messages = [
-            'recipient_region.already_in_activity' => 'Recipient Region is already added at activity level. You can add a Recipient Region either at activity level or at transaction level.',
+            'recipient_region.already_in_activity' => 'Recipient Region or Recipient Country is already added at activity level. You can add a Recipient Region and or Recipient Country either at activity level or at transaction level.',
             'recipient_region.country_or_region' => 'You must add either recipient country or recipient region.',
         ];
 
@@ -630,7 +631,7 @@ class TransactionRequest extends ActivityBaseRequest
     public function getMessagesForRecipientCountry(array $formFields): array
     {
         $messages = [
-            'recipient_country.already_in_activity' => 'Recipient Country is already added at activity level. You can add a Recipient Country either at activity level or at transaction level.',
+            'recipient_country.already_in_activity' => 'Recipient Region or Recipient Country is already added at activity level. You can add a Recipient Region and or Recipient Country either at activity level or at transaction level.',
             'recipient_country.country_or_region' => 'You must add either recipient country or recipient region.',
         ];
 

--- a/app/IATI/Services/Activity/TransactionService.php
+++ b/app/IATI/Services/Activity/TransactionService.php
@@ -451,7 +451,7 @@ class TransactionService
     }
 
     /**
-     * Checks if sector defined in one of the activity transaction.
+     * Checks if recipient country or region already defined in previous transaction.
      *
      * @param $activityId
      * @return bool
@@ -472,5 +472,28 @@ class TransactionService
         }
 
         return false;
+    }
+
+    /**
+     *  Checks if recipient region or country defined in transaction
+     *
+     * @param [type] $activityId
+     * @return boolean
+     */
+    public function hasRecipientRegionOrCountryDefinedInTransaction($activityId): bool
+    {
+        $hasDefined = false;
+        $transactions = $this->getActivityTransactions($activityId);
+        foreach ($transactions as $transaction) {
+            $recipientRegion = $transaction->transaction['recipient_region'];
+            $recipientCountry = $transaction->transaction['recipient_country'];
+
+            if (!is_variable_null($recipientCountry) || !is_variable_null($recipientRegion)) {
+                $hasDefined = true;
+                break;
+            }
+        }
+
+        return $hasDefined;
     }
 }

--- a/app/IATI/Services/Activity/TransactionService.php
+++ b/app/IATI/Services/Activity/TransactionService.php
@@ -484,6 +484,7 @@ class TransactionService
     {
         $hasDefined = false;
         $transactions = $this->getActivityTransactions($activityId);
+
         foreach ($transactions as $transaction) {
             $recipientRegion = $transaction->transaction['recipient_region'];
             $recipientCountry = $transaction->transaction['recipient_country'];


### PR DESCRIPTION
…lidation message thrown at transaction level

	- [x] Each transaction can either have recipient region or recipient country