### PR TITLE
	Review: if recipient region or country added at activity level then va…

### DIFF
--- a/app/Http/Requests/Activity/Transaction/TransactionRequest.php
+++ b/app/Http/Requests/Activity/Transaction/TransactionRequest.php
@@ -508,6 +508,13 @@ class TransactionRequest extends ActivityBaseRequest
             }
         }
 
+        if (!is_variable_null($formFields) && !is_variable_null($this->all()['recipient_region'])) {
+            Validator::extend('country_or_region', function () {
+                return false;
+            });
+            $rules['recipient_region'] = 'country_or_region';
+        }
+
         return $rules;
     }
 
@@ -520,7 +527,10 @@ class TransactionRequest extends ActivityBaseRequest
      */
     public function getMessagesForRecipientRegion(array $formFields): array
     {
-        $messages = ['recipient_region.already_in_activity' => 'Recipient Region already defined in Activity so cannot be mentioned in transaction.'];
+        $messages = [
+            'recipient_region.already_in_activity' => 'Recipient Region is already added at activity level. You can add a Recipient Region either at activity level or at transaction level.',
+            'recipient_region.country_or_region' => 'You must add either recipient country or recipient region.',
+        ];
 
         if (!$formFields) {
             return $messages;
@@ -590,6 +600,13 @@ class TransactionRequest extends ActivityBaseRequest
             }
         }
 
+        if (!is_variable_null($formFields) && !is_variable_null($this->all()['recipient_region'])) {
+            Validator::extend('country_or_region', function () {
+                return false;
+            });
+            $rules['recipient_country'] = 'country_or_region';
+        }
+
         return $rules;
     }
 
@@ -602,7 +619,10 @@ class TransactionRequest extends ActivityBaseRequest
      */
     public function getMessagesForRecipientCountry(array $formFields): array
     {
-        $messages = ['recipient_country.already_in_activity' => 'Recipient Country already defined in Activity so cannot be mentioned in transaction.'];
+        $messages = [
+            'recipient_country.already_in_activity' => 'Recipient Country is already added at activity level. You can add a Recipient Country either at activity level or at transaction level.',
+            'recipient_country.country_or_region' => 'You must add either recipient country or recipient region.',
+        ];
 
         if (!$formFields) {
             return $messages;


### PR DESCRIPTION
…lidation message thrown at transaction level

	- [x] Each transaction can either have recipient region or recipient country