### PR TITLE
Review: 1185-dashboard-visualization-api-hot-fix

### DIFF
--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/js/app.js": "/js/app.js?id=1b4a8788233e1c5bff0d888f84686619",
+    "/js/app.js": "/js/app.js?id=9ffb728b7cce86f91d27964396c10468",
     "/js/script.js": "/js/script.js?id=4920eb85d84da1e87cb71769c04a12a2",
     "/js/webportal-script.js": "/js/webportal-script.js?id=f9c23d4bccd261db9414465886315f45",
     "/js/formbuilder.js": "/js/formbuilder.js?id=96f1b9dd5890b8ff09e613117dd94592",

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/js/app.js": "/js/app.js?id=e296ba9ea3771f53bd685007a0ab5d11",
+    "/js/app.js": "/js/app.js?id=1b4a8788233e1c5bff0d888f84686619",
     "/js/script.js": "/js/script.js?id=4920eb85d84da1e87cb71769c04a12a2",
     "/js/webportal-script.js": "/js/webportal-script.js?id=f9c23d4bccd261db9414465886315f45",
     "/js/formbuilder.js": "/js/formbuilder.js?id=96f1b9dd5890b8ff09e613117dd94592",

--- a/resources/assets/js/views/user/UserListing.vue
+++ b/resources/assets/js/views/user/UserListing.vue
@@ -501,7 +501,7 @@
                 <span>Email</span>
               </th>
 
-              <th id="title" scope="col">
+              <th id="title" v-if="userRole === 'superadmin'" scope="col">
                 <span class="inline-flex items-center">
                   <span
                     v-if="

--- a/resources/assets/js/views/user/UserListing.vue
+++ b/resources/assets/js/views/user/UserListing.vue
@@ -501,7 +501,7 @@
                 <span>Email</span>
               </th>
 
-              <th id="title" v-if="userRole === 'superadmin'" scope="col">
+              <th v-if="userRole === 'superadmin'" id="title" scope="col">
                 <span class="inline-flex items-center">
                   <span
                     v-if="


### PR DESCRIPTION
### Issue: Broken Organization's user listing page

![image](https://github.com/younginnovations/iatipublisher/assets/57512059/88a62d6d-b5a3-4b12-81ec-5fb1bd6772a0)
---
### Cause : Missing user-role check when rendering  user listing page's table
---
### Solution: Added user-role check when rendering user listing page's table