### PR TITLE
Review: 1493-remove-requirement-for-a-revised-activity-budget-to-have-an-equivalent-original-budget

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-php artisan command:SetAppDataJsonCache && \
 php artisan test && \
 npx stylelint "resources/**/*.scss" --fix && \
 npm run lint && \

--- a/app/CsvImporter/Entities/Activity/Components/Factory/Validation.php
+++ b/app/CsvImporter/Entities/Activity/Components/Factory/Validation.php
@@ -707,10 +707,6 @@ class Validation extends Factory
         $this->extend('budgets_identical', function () {
             return false;
         });
-
-        $this->extend('budget_revised_invalid', function () {
-            return false;
-        });
     }
 
     /**

--- a/app/XlsImporter/Validator/Traits/RegistersValidationRules.php
+++ b/app/XlsImporter/Validator/Traits/RegistersValidationRules.php
@@ -687,10 +687,6 @@ trait RegistersValidationRules
         $this->extend('budgets_identical', function () {
             return false;
         });
-
-        $this->extend('budget_revised_invalid', function () {
-            return false;
-        });
     }
 
     /**

--- a/app/Xml/Validator/Traits/RegistersValidationRules.php
+++ b/app/Xml/Validator/Traits/RegistersValidationRules.php
@@ -689,10 +689,6 @@ trait RegistersValidationRules
         $this->extend('budgets_identical', function () {
             return false;
         });
-
-        $this->extend('budget_revised_invalid', function () {
-            return false;
-        });
     }
 
     /**

--- a/tests/Unit/Csv/BudgetCsvTest.php
+++ b/tests/Unit/Csv/BudgetCsvTest.php
@@ -91,24 +91,25 @@ class BudgetCsvTest extends CsvBaseTest
     }
 
     /**
-     * Revised date not matched with one of the budget type original.
+     * Do not throw validation if revised not match with budget period.
+     * Change source: https://github.com/younginnovations/iatipublisher/issues/1493.
      *
      * @return void
      * @test
      * @throws \JsonException
      */
-    public function throw_validation_if_revised_period_do_not_match_one_of_budget_period(): void
+    public function do_not_throw_validation_if_revised_period_do_not_match_one_of_budget_period(): void
     {
         $this->signIn();
         $rows = $this->get_revised_period_not_matched_date();
         $errors = $this->getErrors($rows);
         $flattenErrors = Arr::flatten($errors);
 
-        $this->assertContains('Budget with type revised must have period start and end same to that of one of the budgets having same type original for budgets elements at position 2', $flattenErrors);
+        $this->assertEmpty($flattenErrors);
     }
 
     /**
-     * Invalid reviosed period.
+     * Invalid revised period.
      *
      * @return array
      */

--- a/tests/Unit/Xml/BudgetXmlTest.php
+++ b/tests/Unit/Xml/BudgetXmlTest.php
@@ -195,16 +195,17 @@ class BudgetXmlTest extends XmlBaseTest
     }
 
     /**
-     * Throw validation if revised not match with budget period.
+     * Do not throw validation if revised not match with budget period.
+     * Change source: https://github.com/younginnovations/iatipublisher/issues/1493.
      *
      * @return void
      * @test
      */
-    public function throw_validation_if_revised_period_do_not_match_one_of_budget_period(): void
+    public function do_not_throw_validation_if_revised_period_do_not_match_one_of_budget_period(): void
     {
         $rows = $this->get_revised_period_not_matched_date();
         $flattenErrors = $this->getErrors($rows);
-        $this->assertContains('Budget with type revised must have period start and end same to that of one of the budgets having same type original for budgets elements at position 2', $flattenErrors);
+        $this->assertEmpty($flattenErrors);
     }
 
     /**


### PR DESCRIPTION
- [x] Remove requirement for a 'revised' activity budget to have an equivalent 'original' budget