### PR TITLE
synced users by email and orgs by identifier

### DIFF
--- a/app/IATI/Services/RegisterYourDataApi/IatiDataSyncService.php
+++ b/app/IATI/Services/RegisterYourDataApi/IatiDataSyncService.php
@@ -18,7 +18,7 @@ class IatiDataSyncService
 
     public function syncOrganizationDownstream(string $uuid, array $data): Organization
     {
-        $existingOrg = Organization::where('uuid', $uuid)->first();
+        $existingOrg = Organization::where('identifier', $data['organisation_identifier'])->first();
 
         $publisherTypeCode = data_get($data, 'organisation_type');
         $name = [['narrative' => data_get($data, 'human_readable_name'), 'language' => 'en']];
@@ -136,7 +136,7 @@ class IatiDataSyncService
 
     public function syncUserFromClaims(string $uuid, array $claims, int|null $orgId, string $publisherUserRole): User
     {
-        $user = User::where('uuid', $uuid)->first();
+        $user = User::where('email', data_get($claims, 'email'))->first();
 
         if ($user) {
             $user->update([


### PR DESCRIPTION
syncing by UUID will cause issues: so 

- Syncing users by email
- Syncing organisations by their identifier
- Only datasets are synced by uuids

This will close [1913](https://github.com/IATI/iatipublisher/issues/1913)